### PR TITLE
[DDST-342, FDSF4-18] include title in field mapping

### DIFF
--- a/src/Plugin/OaiMetadataMap/DgiStandard.php
+++ b/src/Plugin/OaiMetadataMap/DgiStandard.php
@@ -37,6 +37,7 @@ class DgiStandard extends OaiMetadataMapBase implements ContainerFactoryPluginIn
    * @var string[]
    */
   protected const FIELD_MAPPING = [
+    'title' => self::TITLE_ELEMENT_MAIN,
     'field_member_of' => 'dcterms:isPartOf',
     'field_resource_type' => 'dcterms:type',
     'field_table_of_contents' => 'dcterms:description',

--- a/src/Plugin/OaiMetadataMap/QDC.php
+++ b/src/Plugin/OaiMetadataMap/QDC.php
@@ -66,6 +66,7 @@ class QDC extends DgiStandard {
    * {@inheritDoc}
    */
   protected const FIELD_MAPPING = [
+    'title' => self::TITLE_ELEMENT_MAIN,
     'field_member_of' => 'dcterms:isPartOf',
     'field_resource_type' => 'dcterms:type',
     'field_genre' => 'dcterms:type',


### PR DESCRIPTION
particularly important for nodes that don't have field_title populated.

It seems this change was intended a while ago, but got lost in the shuffle, so including some related ticket IDs in the PR and putting this together now in hopes of getting this addressed sooner than later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAI-PMH exports now include item titles in the primary title element for both QDC and DGI metadata formats, ensuring titles appear as expected in harvested records.
  * Improves consistency and interoperability with downstream systems and indexes that rely on the main title field.
  * No other behaviors changed; existing mappings and output remain the same aside from the added title exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->