### PR TITLE
FDSF4-18: Fallback to the label if no title has been set.

### DIFF
--- a/src/Plugin/OaiMetadataMap/DgiStandard.php
+++ b/src/Plugin/OaiMetadataMap/DgiStandard.php
@@ -422,6 +422,8 @@ class DgiStandard extends OaiMetadataMapBase implements ContainerFactoryPluginIn
     if (static::THUMBNAIL_ELEMENT) {
       $this->addThumbnail($entity, static::THUMBNAIL_ELEMENT);
     }
+    // Fallback to the label if no title.
+    $this->addFallbackTitle($entity);
   }
 
   /**
@@ -649,6 +651,18 @@ class DgiStandard extends OaiMetadataMapBase implements ContainerFactoryPluginIn
    */
   protected function isParagraphField($paragraph_name) {
     return isset($this->paragraphMapping[$paragraph_name]);
+  }
+
+  /**
+   * Ensures a title is set if one hasn't been added.
+   *
+   * * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   * *   The entity being rendered.
+   */
+  protected function addFallbackTitle(ContentEntityInterface $entity): void {
+    if (!isset($this->elements[static::TITLE_ELEMENT_MAIN])) {
+      $this->elements[static::TITLE_ELEMENT_MAIN] = (string) $entity->label();
+    }
   }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures OAI metadata always includes a main title by falling back to the item’s label when no title is present.
  * Prevents empty or missing dcterms:title values, improving consistency for harvesters and downstream displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->