### PR TITLE
Numerous mapping fixes

### DIFF
--- a/src/Plugin/OaiMetadataMap/DgiStandard.php
+++ b/src/Plugin/OaiMetadataMap/DgiStandard.php
@@ -41,6 +41,7 @@ class DgiStandard extends OaiMetadataMapBase implements ContainerFactoryPluginIn
     'field_resource_type' => 'dcterms:type',
     'field_table_of_contents' => 'dcterms:description',
     'field_description' => 'dcterms:description',
+    'field_abstract' => 'dcterms:description',
     'field_language' => 'dc:language',
     'field_target_audience' => 'dcterms:educationLevel',
     'field_local_identifier' => 'dcterms:identifier',

--- a/src/Plugin/OaiMetadataMap/DgiStandard.php
+++ b/src/Plugin/OaiMetadataMap/DgiStandard.php
@@ -112,6 +112,7 @@ class DgiStandard extends OaiMetadataMapBase implements ContainerFactoryPluginIn
    * @var string[]
    */
   protected const LINKED_AGENT_MAPPING = [
+    'relators:art' => 'dcterms:creator',
     'relators:aut' => 'dcterms:creator',
     'relators:ato' => 'dcterms:contributor',
     'relators:cmp' => 'dcterms:creator',
@@ -122,11 +123,13 @@ class DgiStandard extends OaiMetadataMapBase implements ContainerFactoryPluginIn
     'relators:cre' => 'dcterms:creator',
     'relators:dpc' => 'dcterms:contributor',
     'relators:drt' => 'dcterms:contributor',
+    'relators:dsr' => 'dcterms:creator',
     'relators:edt' => 'dcterms:contributor',
     'relators:hst' => 'dcterms:contributor',
     'relators:ive' => 'dcterms:creator',
     'relators:ivr' => 'dcterms:contributor',
     'relators:prf' => 'dcterms:contributor',
+    'relators:pre' => 'dcterms:contributor',
     'relators:pht' => 'dcterms:creator',
     'relators:cph' => 'dcterms:rightsHolder',
     'relators:pbl' => 'dcterms:contributor',

--- a/src/Plugin/OaiMetadataMap/DgiStandard.php
+++ b/src/Plugin/OaiMetadataMap/DgiStandard.php
@@ -117,11 +117,13 @@ class DgiStandard extends OaiMetadataMapBase implements ContainerFactoryPluginIn
     'relators:cmp' => 'dcterms:creator',
     'relators:cnd' => 'dcterms:contributor',
     'relators:ctb' => 'dcterms:contributor',
+    'relators:cur' => 'dcterms:contributor',
     'relators:crp' => 'dcterms:contributor',
     'relators:cre' => 'dcterms:creator',
     'relators:dpc' => 'dcterms:contributor',
     'relators:drt' => 'dcterms:contributor',
     'relators:edt' => 'dcterms:contributor',
+    'relators:hst' => 'dcterms:contributor',
     'relators:ive' => 'dcterms:creator',
     'relators:ivr' => 'dcterms:contributor',
     'relators:prf' => 'dcterms:contributor',
@@ -131,6 +133,7 @@ class DgiStandard extends OaiMetadataMapBase implements ContainerFactoryPluginIn
     'relators:sgn' => 'dcterms:contributor',
     'relators:spk' => 'dcterms:contributor',
     'relators:spn' => 'dcterms:contributor',
+    'relators:ths' => 'dcterms:contributor',
     'relators:vdg' => 'dcterms:contributor',
   ];
 

--- a/src/Plugin/OaiMetadataMap/DgiStandard.php
+++ b/src/Plugin/OaiMetadataMap/DgiStandard.php
@@ -56,6 +56,8 @@ class DgiStandard extends OaiMetadataMapBase implements ContainerFactoryPluginIn
     'field_subject' => 'dcterms:subject',
     'field_temporal_subject' => 'dcterms:temporal',
     'field_geographic_subject' => 'dcterms:spatial',
+    'field_publication_title' => 'dcterms:source',
+    'field_publication_number' => 'dcterms:source',
     'field_coordinates' => 'dcterms:spatial',
     'field_geographic_code' => 'dcterms:spatial',
     'field_lcc_classification' => 'dcterms:subject',


### PR DESCRIPTION
In the recommended implementation, items will either have an abstract OR a description. Theses, for example, have only an abstract, no description.

Without this modification, thesis abstracts are not available to OAI-PMH.

Subsequent updates add the publication title and number to `dcterms:source`, which was entirely missing from the mapping but is a field provided for in the dplava schema: https://dplava.lib.virginia.edu/dplava.xsd; as well as mapping additional Relator terms to the `dc:contributor` and `dc:creator` elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized abstract metadata to use the common description term for more consistent display.
  * Expanded contributor attribution by mapping additional agent relator types to the appropriate contributor field.
  * Improved publication metadata by adding support for publication title and publication number in the sourced metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->